### PR TITLE
fix: Update from deprecated `args` to `arg` command

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -18,7 +18,7 @@ end)
 return {
 	entry = function()
 		local files = selected_files()
-		local cmd = Command("ripdrag"):args({ "-a", "-x" }):args(files)
+		local cmd = Command("ripdrag"):arg({ "-a", "-x" }):arg(files)
 		local child, err = cmd:spawn()
 		if not child then
 			fail("Spawn `ripdrag` failed with error code %s.", err)


### PR DESCRIPTION
This prevents warning messages.