### PR TITLE
update README for recent versions of yazi

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ git clone https://github.com/Joao-Queiroga/drag.yazi.git ~/.config/yazi/plugins/
 git clone https://github.com/Joao-Queiroga/drag.yazi.git %AppData%\yazi\config\plugins\ripdrag.yazi
 
 # Or with yazi plugin manager
-ya pack -a Joao-Queiroga/drag
+ya pkg add Joao-Queiroga/drag
 ```
 
 - Add this to your `keymap.toml`:
 
 ```toml
-[[manager.prepend_keymap]]
+[[mgr.prepend_keymap]]
 on   = [ "<C-d>" ]
 run  = "plugin drag"
 desc = "Drag Files"


### PR DESCRIPTION
`ya pack` and `[manager]` were deprecated and no longer work:
https://github.com/sxyazi/yazi/pull/2770
https://github.com/sxyazi/yazi/pull/2803